### PR TITLE
Added implementation for Group chat creation, fetching and joining

### DIFF
--- a/src/main/java/admin/RMIAdminImpl.java
+++ b/src/main/java/admin/RMIAdminImpl.java
@@ -12,8 +12,7 @@ import java.rmi.registry.Registry;
 import java.rmi.server.RemoteServer;
 import java.rmi.server.ServerNotActiveException;
 import java.rmi.server.UnicastRemoteObject;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -36,6 +35,10 @@ public class RMIAdminImpl extends UnicastRemoteObject implements Admin, StatusMa
   }
 
 
+  // Why does this always return NULL?
+  // Who is supposed to call this method, client or broker?
+  // If the client calls it, then RemoteServer.getClientHost will return
+  // the host name of the client, when we want the host name of the broker
   @Override
   public BrokerInfoPayload registerNewUser(UserInfoPayload user)
       throws RemoteException, InterruptedException {
@@ -48,6 +51,11 @@ public class RMIAdminImpl extends UnicastRemoteObject implements Admin, StatusMa
       e.printStackTrace();
     }
 
+    if (this.brokerRecord.values().size() > 0) {
+      List<BrokerInfoPayload> activeBrokers = new ArrayList<BrokerInfoPayload>(this.brokerRecord.values());
+      return activeBrokers.get(new Random().nextInt(activeBrokers.size()));
+    }
+    // Return null if there are no active brokers
     return null;
   }
 

--- a/src/main/java/admin/StartAdmin.java
+++ b/src/main/java/admin/StartAdmin.java
@@ -8,7 +8,9 @@ import java.rmi.registry.LocateRegistry;
 import java.rmi.registry.Registry;
 
 public class StartAdmin {
-
+  /*
+    Takes only 1 CMD Argument, i.e. the port on which the admin rmi will run.
+   */
   public static void main(String[] args) {
     Registry registry;
     Integer PORT = Integer.valueOf(args[0]);

--- a/src/main/java/broker/StartBroker.java
+++ b/src/main/java/broker/StartBroker.java
@@ -12,6 +12,14 @@ import java.util.UUID;
  */
 public class StartBroker {
 
+  /*
+    Takes 3 CMD Arguments -
+    1. HOST address of admin - pass 127.0.0.1 for local
+    2. PORT of admin
+    3. PORT on which this broker will run. Use unique PORT numbers for each broker.
+    Use $Prompt$ if you want Intellij to pop up an input box for this argument each time you
+    run the broker.
+   */
   public static void main(String[] args) {
 
     Registry registry;

--- a/src/main/java/client/Client.java
+++ b/src/main/java/client/Client.java
@@ -1,5 +1,86 @@
 package client;
 
-public class Client {
+import admin.Admin;
+import common.OutputHandler;
+import common.PingHeartbeat;
+import common.RMIHandler;
+import protocol.BrokerInfoPayload;
+import protocol.UserInfoPayload;
+
+import java.rmi.RemoteException;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * class represents client
+ */
+public class Client implements ClientToBrokerInterface {
+
+    private final String adminHost;
+    private Integer adminPort;
+    private final String adminName = "Admin";
+    private BrokerInfoPayload bip = null;
+
+    private UserInfoPayload selfRecord;
+    private ScheduledExecutorService clientHeartbeatService = Executors.newSingleThreadScheduledExecutor();
+
+    public Client(String username, String adminHost, Integer adminPort) {
+        this.adminHost = adminHost;
+        this.adminPort = adminPort;
+
+        this.selfRecord = new UserInfoPayload(UUID.randomUUID().toString(), username, true);
+    }
+
+
+    /**
+     * Creates a separate thread and starts sending heartbeat to Broker
+     */
+    public void startSendingHearbeat() {
+        clientHeartbeatService.scheduleAtFixedRate(
+                new PingHeartbeat(bip.getHOST(),bip.getPORT(), "Broker", selfRecord), 1, 1,
+                TimeUnit.SECONDS);
+    }
+
+    /**
+     * Note: IF using TCP, delete this method
+     * @param PORT
+     * @param successMessage
+     */
+    public void registerRMI(int PORT, String successMessage) {
+        RMIHandler.registerRemoteObject(selfRecord.getEntityID(), this, PORT, successMessage);
+    }
+
+    /**
+     * Requests the admin to assign a broker to this client
+     * @throws RemoteException
+     * @throws InterruptedException
+     */
+    public void discoverBroker() throws RemoteException, InterruptedException {
+
+        if (adminPort == null) {
+            adminPort = 1099;
+        }
+
+        try {
+            Admin admin = RMIHandler.fetchRemoteObject(adminName, adminHost, adminPort);
+            UserInfoPayload uip = new UserInfoPayload(selfRecord.getEntityID(), selfRecord.getUserName(), true);
+            assert admin != null;
+            bip = admin.registerNewUser(uip);
+        } catch (NullPointerException e) {
+            OutputHandler.printWithTimestamp("Error: admin object is null");
+        } catch (RemoteException | InterruptedException e) {
+            e.printStackTrace();
+        }
+
+    }
+
+
+    @Override
+    public void sendUserUpdateInfo(List userUpdateInfo) throws RemoteException {
+
+    }
     // entid
 }

--- a/src/main/java/client/StartClient.java
+++ b/src/main/java/client/StartClient.java
@@ -1,0 +1,32 @@
+package client;
+
+import common.OutputHandler;
+import common.RMIHandler;
+
+import java.rmi.RemoteException;
+
+public class StartClient {
+
+    /**
+     * starts the client and asks for a broker from the admin
+     * @param args arguments of the form "username PORT"
+     * @throws RemoteException
+     * @throws InterruptedException
+     */
+    public static void main(String args[]) throws RemoteException, InterruptedException {
+        // change later to make the name unique
+        String rmiName = "Client";
+        String adminName = "Admin";
+
+        String username = args[0];
+        String adminHost = args[1];
+        Integer adminPORT = Integer.valueOf(args[2]);
+        Integer brokerPort = Integer.valueOf(args[3]);
+        String successMessage = "Client " + rmiName + " successfully registered";
+        Client client = new Client(username, adminHost, adminPORT);
+
+        client.discoverBroker();
+        client.startSendingHearbeat();
+
+    }
+}

--- a/src/main/java/common/RMIHandler.java
+++ b/src/main/java/common/RMIHandler.java
@@ -1,0 +1,67 @@
+package common;
+
+import admin.Admin;
+import admin.RMIAdminImpl;
+
+import java.rmi.AlreadyBoundException;
+import java.rmi.NotBoundException;
+import java.rmi.Remote;
+import java.rmi.RemoteException;
+import java.rmi.registry.LocateRegistry;
+import java.rmi.registry.Registry;
+import java.rmi.server.UnicastRemoteObject;
+
+/**
+ * Class with static methods to register or fetch remote objects
+ */
+public class RMIHandler{
+
+    /**
+     * Register a given object with the RMI registry
+     * @param RMIName the name of the object in the registry
+     * @param obj the object to register
+     * @param PORT the port to register on
+     * @param message the message displayed after successful registration
+     */
+    public static void registerRemoteObject(String RMIName, Remote obj, Integer PORT, String message) {
+        try {
+            Registry registry = LocateRegistry.createRegistry(PORT);
+
+            registry.bind(RMIName, obj);
+            OutputHandler.printWithTimestamp(message);
+        } catch (RemoteException | AlreadyBoundException e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Returns a (typed) remote object given the object's RMI name and a host (if null, then is
+     * localhost)
+     * @param RMIname name of the remote object in the registry
+     * @param host host name of the RMI registry server
+     * @param <T> generic type of object
+     * @return object with the given RMI name
+     */
+    public static <T> T fetchRemoteObject(String RMIname, String host, Integer PORT) {
+
+        String errorMessage = "Error: could not find remote object";
+
+        if (PORT == null) {
+            PORT = 1099;
+        }
+
+        try {
+            String name = RMIname;
+            Registry registry = LocateRegistry.getRegistry(host, PORT);
+            T obj = (T) registry.lookup(name);
+
+            return obj;
+
+        } catch (RemoteException | NotBoundException e) {
+            System.err.println(errorMessage);
+            e.printStackTrace();
+            return null;
+        }
+    }
+}
+


### PR DESCRIPTION
The user can do the following using the implementation in the code - 

1. Create a group chat
2. Join a existing group chat
3. Get list of all group chats
4. Leave a already joined Group